### PR TITLE
Relaxing version dependencies on lazy_static and rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ keywords = ["nuid","guid","uuid"]
 description = "A highly performant unique identifier generator."
 
 [dependencies]
-lazy_static = "^1.0"
-rand = "^0.4"
+lazy_static = "^1.2"
+rand = "^0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ keywords = ["nuid","guid","uuid"]
 description = "A highly performant unique identifier generator."
 
 [dependencies]
-lazy_static = "~1.0"
-rand = "~0.4"
+lazy_static = "^1.0"
+rand = "^0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Copied here due to lazy_static version collision.
 #[macro_use]
 extern crate lazy_static;
 extern crate rand;
@@ -180,7 +179,7 @@ mod tests {
     #[test]
     fn unique() {
         let mut set = HashSet::new();
-        for _ in 0..10_00_000 {
+        for _ in 0..10_000_000 {
             assert_eq!(set.insert(next()), true);
         }
 


### PR DESCRIPTION
The current version cannot be linked with other libs that use lazy_static v1.2.0.

----------- Error Message -------------
failed to select a version for `lazy_static`.
    ... required by package `nuid v0.1.0`
versions that meet the requirements `~1.0` are: 1.0.2, 1.0.1, 1.0.0