### PR TITLE
Constraint rand version dependency. Bump version to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 edition = "2018"
 name = "nuid"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ivan Porto Carrero <ivan@oflanders.co.nz>"]
 license = "Apache-2.0"
 repository = "https://github.com/casualjim/rs-nuid.git"
 readme = "README.md"
-keywords = ["nuid","guid","uuid"]
+keywords = ["nuid", "guid", "uuid"]
 description = "A highly performant unique identifier generator."
 
 [dependencies]
 lazy_static = "^1.2"
-rand = "0"
+rand = ">=0.8"


### PR DESCRIPTION
Build failed, when I tried to compile project with `nats = "0.16"` dependency.
Cargo tried to reuse `rand v0.7.3` provided by some other package (I guess that was `ed25519-dalek` used by `nkeys`) with incompatible `rng.gen_range` signature that requires two arguments `low` and `high` instead of `Range`. 

fixes #3