### PR TITLE
Drop `once_cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ description = "A highly performant unique identifier generator."
 categories = ["data-structures", "date-and-time", "value-formatting", "encoding", "parsing"]
 
 [dependencies]
-once_cell = "1"
 rand = ">=0.8"


### PR DESCRIPTION
This raises the MSRV to 1.63, version that got released 1 year ago so it should be fine.