### PR TITLE
Fix rand version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ description = "A highly performant unique identifier generator."
 categories = ["data-structures", "date-and-time", "value-formatting", "encoding", "parsing"]
 
 [dependencies]
-rand = ">=0.8"
+rand = "0.8"


### PR DESCRIPTION
It's bad practice to import dependencies using `>=`. This PR will make it so only `0.8.n` versions of `rand` to be used

Will merge conflict with #7.
I intend to send more PRs after this and #7 have been merged